### PR TITLE
Show correct dates in calendar for Americas

### DIFF
--- a/app/components/calendar-page.js
+++ b/app/components/calendar-page.js
@@ -9,7 +9,7 @@ export default Component.extend({
     day: computed("date", function () {
         const date = get(this, "date");
 
-        return leftPad("00", new Date(date).getDate().toString());
+        return leftPad("00", new Date(date).getUTCDate().toString());
     }),
 
     month: computed("date", function () {


### PR DESCRIPTION
Okay, so this is a locale issue.

**On the transaction edit page**
![screenshot from 2017-01-06 16 18 11](https://cloud.githubusercontent.com/assets/3639540/21733322/c973c83a-d42b-11e6-8a26-c98969c5c2ba.png)
**Same transaction on the calendar page**
![screenshot from 2017-01-06 16 18 23](https://cloud.githubusercontent.com/assets/3639540/21733321/c973ce16-d42b-11e6-88fb-414ed22648b3.png)

You're storing the date as a String: https://github.com/cowbell/splittypie/blob/3f528f2be8662c895841e908545f0af5e8d80232/app/models/transaction.js#L16
```js
date: attr("string"),
```

Then on the calendar page (`https://splittypie.com/xxx/transactions`) you retrieve the date like so:
https://github.com/cowbell/splittypie/blob/3f528f2be8662c895841e908545f0af5e8d80232/app/components/calendar-page.js#L12
```js
return leftPad("00", new Date(date).getDate().toString());
```

The trouble is that the [`Date.prototype.getDate()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getDate) function will return a value according to the user's _locale_.

>The getDate() method returns the day of the month for the specified date according to local time.

As a consequence, being in UTC-5 means that if I input "January 15" into the "new transaction" page, I will see "January 14" on the calendar page. This is because `Jan 15 2017 00:00:00 UTC` becomes converted to `Jan 14 19:00:00 UTC-5` when it's converted to my locale.

Ideally what we _really_ want is for my inputted Date to be converted from my locale into UTC _before_ being stored into the database. I'm in favor of this, but have taken a more conservative approach with my PR since I don't know how many users would be affected by this change.

So instead, I've switched to [`Date.prototype.getUTCDate()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCDate) so the inputted date will be in UTC and the displayed date will also be in UTC without being converted. This does mean that everyone will be storing and retrieving dates according to the wrong locale unless they're in the UK, but to the end user it doesn't really matter.

It's really funny to me that you've even included [a unit test](https://github.com/cowbell/splittypie/blob/e5027237bda5930faf080b4abb658db07a19dbd7/tests/acceptance/transaction-test.js#L87) for this, but it appears correct to you because you're in Poland (UTC+1)! Thus `Jan 15 2017 00:00:00` becomes converted into `Jan 15 2017 01:00:00` and you are none the wiser since the calendar month, day, and year are correct. I feel like there's a lot that could be said here about the reliability of unit tests. You can't test what you don't know!

Anyway, I digress. This PR should fix the issue, but it's probably better to convert from locale to UTC before saving the form instead, if you don't think your users will be harmed by that change.