### PR TITLE
Solve Android fullscreen 'problem' if installed to home screen.

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "Splittypie",
   "theme_color": "#ffffff",
   "background_color": "#ffffff",
-  "display": "fullscreen",
+  "display": "standalone",
   "orientation": "portrait",
   "start_url": "/",
   "icons": [


### PR DESCRIPTION
First of all, I love the app!! So thank you very much for that!!! :+1:

I use Chromium instead of Chrome on my Android device and it actually launches in fullscreen (although in Chrome it seems to work correctly). This also happens with Chrome Beta for Android.

Here you have a screenshot from my device with the app launched from the home screen:

![splittypie fullscreen](https://cloud.githubusercontent.com/assets/6866042/25565370/0ae3342e-2dc6-11e7-9409-bc09e5bdf538.png)

Taking a look at the git history I've seen that it used to be set to `standalone` and you changed it too `fullscreen`. I also have no idea about progressive web apps (which I have just learned about and which I really like). So you might have a good reason for that and might just want to ignore me :wink:

I have just tested it on my server and (with very little testing) it seems to be working.

Again, thanks for the app!

Cheers,
Juanito